### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Synaudit Go CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/gaetangr/synaudit/security/code-scanning/1](https://github.com/gaetangr/synaudit/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code, sets up Go, caches dependencies, runs tests, and uploads coverage (but does not push code, create releases, or modify issues/pull requests), the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the `build` job). The best practice is to set it at the workflow level unless a job needs different permissions. Add the following block after the `name:` line and before `on:`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
